### PR TITLE
Update pom.xml to use sl4j-api 1.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,14 +56,9 @@
             <version>1.8.3</version>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>0.9.24</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.5</version>
         </dependency>
         <dependency>
             <groupId>com.metapossum</groupId>


### PR DESCRIPTION
This change will update Model-Citizen to use slf4j-api version 1.7.5 over slf4j-api 1.6.1.

This change is due in part to the following exception being thrown:

java.lang.NoSuchMethodError: ch.qos.logback.classic.LoggerContext.getBithTime()

Upon further investigation I found the following:
## January 25th, 2011 - Release of version 0.9.28
### Breaking change: In the Context interface, the previously misspelled property bithTime is now renamed as birthTime.

In the Context interface, the previously misspelled property bithTime is now renamed as birthTime. This is a backward-incompatible change. All pre-existing references to "bithTime" property now need to referenced as "birthTime".

Tests passed locally.
