### PR TITLE
Remove the GPG plugin on debug build paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,20 +117,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0.2</version>
                 <configuration>


### PR DESCRIPTION
The config for this was duplicated in the main build config and the release profile. This isn’t necessary when installing to the local Maven cache so I removed it from the main build config.
