### PR TITLE
Update README.md: Upstream is now factory_bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Java CI with Maven](https://github.com/mguymon/model-citizen/actions/workflows/maven.yml/badge.svg)](https://github.com/mguymon/model-citizen/actions/workflows/maven.yml)
 
-Model Citizen is an annotation based model factory for Java, inspired by [FactoryGirl](https://github.com/thoughtbot/factory_girl)
+Model Citizen is an annotation based model factory for Java, inspired by [factory_bot](https://github.com/thoughtbot/factory_bot)
 
 A Model is mapped by a _@Blueprint_ using annotated fields. Blueprints contain
 default values and references to other @Blueprinted models. The _ModelFactory_ can


### PR DESCRIPTION
Reasoning (which itself could go master to main): https://github.com/thoughtbot/factory_bot/blob/master/NAME.md#factory-bot

i.e. today https://github.com/thoughtbot/factory_girl redirects to https://github.com/thoughtbot/factory_bot